### PR TITLE
pass dotenv.load options

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -2,15 +2,23 @@ var dotenv = require('dotenv')
   , through = require('through')
   , jstransform = require('jstransform')
   , createVisitors = require('./visitors')
+  , deepEqual = require('deep-equal')
 
 var processEnvPattern = /\bprocess\.env\b/
 
-dotenv.load();
+var _options, _result
+function loadEnv (argv) {
+  var options = {silent: argv.silent, path: argv.path, encoding: argv.encoding}
+  if (_result === true && deepEqual(options, _options)) return
+  _result = dotenv.load(argv)
+  _options = options
+}
 
 module.exports = function(rootEnv) {
   rootEnv = rootEnv || process.env || {}
 
   return function dotenvify(file, argv) {
+    loadEnv(argv)
     if (/\.json$/.test(file)) return through()
 
     var buffer = []

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tape": "~2.3.2"
   },
   "dependencies": {
+    "deep-equal": "^1.0.1",
     "dotenv": "^1.1.0",
     "jstransform": "^10.0.1",
     "through": "~2.3.4"


### PR DESCRIPTION
[dotenv has](https://www.npmjs.com/package/dotenv#options) `silent` `path` `encoding` options.

this PR enables following usage

```
$ browserify -t [ dotenvify --silent --path local.env ] src/index.js -o dist/index.js
```
